### PR TITLE
Fixes gridinitialisation first argument

### DIFF
--- a/examples/01_beginner/gol.html
+++ b/examples/01_beginner/gol.html
@@ -48,7 +48,7 @@ function cacatoo(){
     */
     sim = new Simulation(config)                          // Initialise the Cacatoo simulation    
     sim.makeGridmodel("gol")                              // Build a new Gridmodel within the simulation called "gol" (Game Of Life)
-    sim.initialGrid("gol", 'alive', 0, 1, 0.5)                // Set half (50%) of the Gridmodel's grid points to 1 (alive)
+    sim.initialGrid(sim.gol, 'alive', 0, 1, 0.5)                // Set half (50%) of the Gridmodel's grid points to 1 (alive)
     sim.createDisplay("gol", "alive", "Game of life (white=alive)")                      // Create a display so we can see our newly made gridmodel
 
     /*


### PR DESCRIPTION
Fixes this bug:
When I open the Game of Life example (examples/01_beginner/gol.html) with a VSCode Live Server, all I see is the page header. There's no grid created.

By changing line 51 the first argument to sim.gol, when I make that change on my computer and run it with a VSCode Live Server, I get an initialised grid.

## Summary by Sourcery

Bug Fixes:
- Pass sim.gol instead of its name string to sim.initialGrid in gol.html to restore the initial grid creation.