### PR TITLE
Fixes grid initialization in interacting_grids.html

### DIFF
--- a/examples/01_beginner/interacting_grids.html
+++ b/examples/01_beginner/interacting_grids.html
@@ -38,12 +38,12 @@
         sim = new Simulation(config)
 
         sim.makeGridmodel("gol");
-        sim.initialGrid("gol", 'alive', 0, 1, 0.1)
+        sim.initialGrid(sim.gol, 'alive', 0, 1, 0.1)
         sim.createDisplay("gol", "alive", "Game of life (solo)")
 
         sim.makeGridmodel("vote");
-        sim.initialGrid("vote", 'left', 0, 1, 0.5)           // Give each grid-point object a new property names 'val', with 50% 1, otherwise 0
-        sim.initialGrid("vote", 'overlay', 0)        // Give each grid-point object a new property names 'val', with 50% 1, otherwise 0
+        sim.initialGrid(sim.vote, 'left', 0, 1, 0.5)           // Give each grid-point object a new property names 'val', with 50% 1, otherwise 0
+        sim.initialGrid(sim.vote, 'overlay', 0)        // Give each grid-point object a new property names 'val', with 50% 1, otherwise 0
         sim.createDisplay("vote", "overlay", "Vote / Game of life interact")
 
         sim.gol.nextState = function (x,y)                 // Define the next-state function. This example is game of life + vote


### PR DESCRIPTION
Same logic as the fix in gol.html.

## Summary by Sourcery

Fix grid initialization in interacting_grids.html by passing grid model objects to initialGrid calls instead of string names to ensure proper setup of Game of Life and vote grids.

Bug Fixes:
- Change initialGrid calls to use sim.gol instead of "gol" for Game of Life initialization
- Change initialGrid calls to use sim.vote instead of "vote" for vote grid initializations