### PR TITLE
Fixes dist and lib links in empty_project.html

### DIFF
--- a/examples/empty_project.html
+++ b/examples/empty_project.html
@@ -5,8 +5,8 @@
 -->
 
 <html>
-<script src="../../dist/cacatoo.js"></script> <!-- Include cacatoo library (compiled with rollup) -->
-<script src="../../lib/all.js"></script> <!-- Include other libraries (concattenated in 1 file) -->
+<script src="../dist/cacatoo.js"></script> <!-- Include cacatoo library (compiled with rollup) -->
+<script src="../lib/all.js"></script> <!-- Include other libraries (concattenated in 1 file) -->
 <link rel="stylesheet" href="../../style/cacatoo.css"> <!-- Set style sheet -->
 
 <head>


### PR DESCRIPTION
Both links were one level too deep (at the same level as e.g. the beginner examples).
I tested this fix by clicking on the links in VSCode studio and it found the files, where before it couldn't.

## Summary by Sourcery

Bug Fixes:
- Correct the relative paths for dist and lib script references in the empty project example