### PR TITLE
Fix petridish.js cmd_params

### DIFF
--- a/examples/05_example_node_project/petridish.js
+++ b/examples/05_example_node_project/petridish.js
@@ -9,7 +9,7 @@
 //Simulation = require('cacatoo') // Loads the Simulation class from installation, or from local package like below
 Simulation = require('../../dist/cacatoo') // Loads the Simulation class from installation, or from local package like below
 let yargs = require('yargs')
-let cmd_params = yargs.argv
+let cmd_params = yargs(process.argv).argv
 
 let birth_rate = 0.85   
 let mutationrate = cmd_params.mu ? cmd_params.mu : 0.00005


### PR DESCRIPTION
Before editing, I got a TypeError: Cannot read properties of undefined (reading 'mu') when running the script as described in the comments at the top of the file. With this edit, I get expected output.

## Summary by Sourcery

Bug Fixes:
- Replace deprecated yargs.argv with yargs(process.argv).argv for correct cmd_params parsing in example script