### PR TITLE
Fixes printGrid method for loop scoping.

### DIFF
--- a/dist/cacatoo.js
+++ b/dist/cacatoo.js
@@ -1435,10 +1435,12 @@ class Gridmodel {
 
         if (fract != undefined) ncol *= fract, nrow *= fract;
         let grid = new Array(nrow);             // Makes a column or <rows> long --> grid[cols]
-        for (let x = 0; x < ncol; x++)
+        for (let x = 0; x < ncol; x++) {
             grid[x] = new Array(ncol);          // Insert a row of <cols> long   --> grid[cols][rows]
-        for (let y = 0; y < nrow; y++)
-            grid[x][y] = this.grid[x][y][property];
+            for (let y = 0; y < nrow; y++) {
+                grid[x][y] = this.grid[x][y][property];
+            }
+        }
 
         console.table(grid);
     }
@@ -4741,6 +4743,7 @@ function get2DFromCanvas(canvas) {
         rows++;
     }
     return arr2D
+
 }
 
 


### PR DESCRIPTION
As written, the for loops weren't nested, meaning the x-variable was undefined in the y-loop and the method errored.
This should solve that problem. I tested it on my local Cacatoo copy and it works perfectly there.

## Summary by Sourcery

Fix loop scoping in the printGrid method and tidy up formatting in the distributed JavaScript file.

Enhancements:
- Add missing braces to properly nest the x and y loops in printGrid to prevent undefined variable errors
- Normalize blank lines and brace placement throughout the generated dist file for consistent formatting